### PR TITLE
fix: improve Python compatibility and type safety

### DIFF
--- a/crashlogtools/crashloglabeler.py
+++ b/crashlogtools/crashloglabeler.py
@@ -83,7 +83,8 @@ class CrashLogLabeler(IPlugin):
     def onUserInterfaceInitializedCallback(self, main_window: "QMainWindow"):
         game = self.organizer.managedGame().gameName()
         self.finder = crashlogs.get_finder(game)
-        if not self.finder:
+
+        if self.finder is None:
             return
         self.processor = CrashLogProcessor(game, lambda file: QFile(str(file)).moveToTrash())
 

--- a/crashlogtools/crashlogs.py
+++ b/crashlogtools/crashlogs.py
@@ -1,7 +1,7 @@
 import configparser
 import ctypes.wintypes
 from pathlib import Path
-from typing import Set, Optional, Sequence
+from typing import Set, Optional, Sequence, Union
 
 from mobase import IOrganizer
 
@@ -10,7 +10,7 @@ SHGFP_TYPE_CURRENT = 0
 
 
 class CrashLogFinder:
-    def __init__(self, log_directory: str | Path, a_filter: str):
+    def __init__(self, log_directory: Union[str, Path], a_filter: str):
         self.log_directory = log_directory
         self.filter = a_filter
 
@@ -19,7 +19,7 @@ class CrashLogFinder:
         return self._log_directory
 
     @log_directory.setter
-    def log_directory(self, value: str | Path) -> None:
+    def log_directory(self, value: Union[str, Path]) -> None:
         a_value = Path(value).resolve()
         if a_value.is_dir():
             self._log_directory = a_value

--- a/crashlogtools/crashlogviewer.py
+++ b/crashlogtools/crashlogviewer.py
@@ -80,7 +80,7 @@ class CrashLogViewer(IPluginTool):
         if not logs_list:
             return
 
-        proxy_model: FileFilterProxyModel = logs_list.model()
+        proxy_model: FileFilterProxyModel = cast(FileFilterProxyModel, logs_list.model())
         if not proxy_model:
             return
 

--- a/crashlogtools/crashlogviewer.py
+++ b/crashlogtools/crashlogviewer.py
@@ -90,6 +90,7 @@ class CrashLogViewer(IPluginTool):
 
         # Update the source model with the new directory
         new_dir_str = str(new_dir)
+        # noinspection PyUnresolvedReferences
         self.dialog.setWindowTitle(f"Crash Log Viewer - {new_dir_str}")
         source_model.setRootPath(new_dir_str)
 
@@ -107,6 +108,7 @@ class CrashLogViewer(IPluginTool):
         if self.dialog is not None:
             log_dir: Path = self.finder.get_crash_log_dir(self.organizer)
             self.change_log_directory(log_dir)
+            # noinspection PyUnresolvedReferences
             self.dialog.show()
 
     def onUserInterfaceInitializedCallback(self, main_window: QMainWindow):


### PR DESCRIPTION
- Replace union type syntax (str | Path) with Union[str, Path] for Python < 3.10 compatibility
- Add explicit type casting for proxy_model to improve type safety
- Convert file I/O from text mode to binary mode in CrashLogProcessor
- Update regex patterns and string operations to work with bytes

all so that no more issues like this occurs:
an error occurred: UnicodeDecodeError: 'utf-8' codec can't decode byte Oxcc in position 1147: invalid continuation byte
At:
<frozen codecs> (322): decode
G:\MO2/plugins\crashlogtools\crashlogutil.py(130): read_file G:\MO2/plugins\crashlogtools\crashlogutil.py(109): __init_
G:\MO2/plugins\crashlogtools\crashlogutil.py(50): process_log G:\MO2/plugins\crashlogtools\crashloglabeler.py(95):
onUserInterfacelnitializedCallback